### PR TITLE
Add volumetric lighting + heatmap visualization (OmniLumen MVP step 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# OmniLumen Visualizer
+
+OmniLumen Visualizer is a browser-based playground for previewing Acolyte fixture photometry using Three.js. Load IES files from the sidebar, adjust light attributes, and inspect how the beam interacts with the virtual environment.
+
+## Scene Controls
+
+The **Scene Controls** card in the sidebar drives the currently selected light. In addition to the existing intensity, CCT, yaw, and pitch sliders, two new toggles are available:
+
+- **Volumetrics** – renders a physically inspired volumetric cone that scales with the fixture's intensity and beam angle so you can see the beam cutting through space.
+- **Heatmap** – overlays an approximate illuminance heatmap on the floor for the selected light. The gradient updates live as you adjust intensity, color temperature, yaw, or pitch.
+
+Both effects are lightweight shader-driven additions that respect the original Three.js renderer configuration and run in Replit without extra dependencies.

--- a/client/heatmap.js
+++ b/client/heatmap.js
@@ -1,0 +1,122 @@
+import * as THREE from "three";
+
+const _lightPos = new THREE.Vector3();
+const _targetPos = new THREE.Vector3();
+const _direction = new THREE.Vector3();
+
+export function createHeatmapPlane({ size = 25, resolution = 64 } = {}) {
+  const geometry = new THREE.PlaneGeometry(size, size, resolution, resolution);
+
+  const uniforms = {
+    uLightPos: { value: new THREE.Vector3() },
+    uLightDir: { value: new THREE.Vector3(0, -1, 0) },
+    uCosHalfAngle: { value: Math.cos(THREE.MathUtils.degToRad(40)) },
+    uIntensity: { value: 0 },
+    uReferenceLux: { value: 150 },
+    uMaxDistance: { value: 40 },
+    uEnabled: { value: 0 },
+  };
+
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    vertexShader: /* glsl */ `
+      varying vec3 vWorldPosition;
+
+      void main() {
+        vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+        vWorldPosition = worldPosition.xyz;
+        gl_Position = projectionMatrix * viewMatrix * worldPosition;
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      uniform vec3 uLightPos;
+      uniform vec3 uLightDir;
+      uniform float uCosHalfAngle;
+      uniform float uIntensity;
+      uniform float uReferenceLux;
+      uniform float uMaxDistance;
+      uniform float uEnabled;
+
+      varying vec3 vWorldPosition;
+
+      vec3 gradient(float t) {
+        const vec3 c0 = vec3(0.0, 0.1, 0.7);
+        const vec3 c1 = vec3(0.0, 0.65, 0.35);
+        const vec3 c2 = vec3(0.95, 0.82, 0.15);
+        const vec3 c3 = vec3(1.0, 1.0, 1.0);
+        if (t < 0.33) {
+          float f = smoothstep(0.0, 0.33, t);
+          return mix(c0, c1, f);
+        } else if (t < 0.66) {
+          float f = smoothstep(0.33, 0.66, t);
+          return mix(c1, c2, f);
+        }
+        float f = smoothstep(0.66, 1.0, t);
+        return mix(c2, c3, f);
+      }
+
+      void main() {
+        if (uEnabled < 0.5) {
+          discard;
+        }
+
+        vec3 toPoint = vWorldPosition - uLightPos;
+        float distance = length(toPoint);
+        if (distance > uMaxDistance) {
+          discard;
+        }
+
+        vec3 lightToPoint = distance > 0.0 ? toPoint / distance : vec3(0.0);
+        float coneStrength = smoothstep(uCosHalfAngle, uCosHalfAngle + 0.12, dot(lightToPoint, uLightDir));
+        if (coneStrength <= 0.001) {
+          discard;
+        }
+
+        float vertical = clamp(-lightToPoint.y, 0.0, 1.0);
+        float lux = uIntensity * coneStrength * vertical / max(distance * distance, 0.5);
+
+        float normalized = clamp(pow(lux / max(uReferenceLux, 0.0001), 0.42), 0.0, 1.0);
+        vec3 color = gradient(normalized);
+        float alpha = normalized * 0.85;
+
+        if (alpha <= 0.002) {
+          discard;
+        }
+
+        gl_FragColor = vec4(color, alpha);
+      }
+    `,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.position.y = 0.012;
+  mesh.renderOrder = 2;
+  mesh.name = "PhotometricHeatmap";
+  return mesh;
+}
+
+export function updateHeatmapUniforms(mesh, { light, target, intensity, enabled }) {
+  if (!mesh || !mesh.material || !mesh.material.uniforms) return;
+
+  const uniforms = mesh.material.uniforms;
+  uniforms.uEnabled.value = enabled ? 1 : 0;
+  if (!enabled || !light || !target) {
+    return;
+  }
+
+  light.getWorldPosition(_lightPos);
+  target.getWorldPosition(_targetPos);
+  _direction.copy(_targetPos).sub(_lightPos).normalize();
+
+  uniforms.uLightPos.value.copy(_lightPos);
+  uniforms.uLightDir.value.copy(_direction);
+  uniforms.uCosHalfAngle.value = Math.cos(light.angle);
+  uniforms.uIntensity.value = intensity;
+  uniforms.uMaxDistance.value = Math.max(light.distance, 15);
+  uniforms.uReferenceLux.value = Math.max(intensity / 12, 60);
+}

--- a/client/index.html
+++ b/client/index.html
@@ -162,6 +162,23 @@
         color: rgba(255, 255, 255, 0.75);
       }
 
+      .control-toggle label {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        font-size: 0.82rem;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: rgba(245, 247, 251, 0.78);
+      }
+
+      .control-toggle input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: #ffc857;
+        cursor: pointer;
+      }
+
       input[type="range"] {
         -webkit-appearance: none;
         appearance: none;
@@ -373,6 +390,18 @@
             />
             <span class="range-value" id="pitch-value">-90°</span>
           </div>
+        </div>
+        <div class="control-field control-toggle">
+          <label for="volumetrics-toggle">
+            <input type="checkbox" id="volumetrics-toggle" />
+            Volumetrics
+          </label>
+        </div>
+        <div class="control-field control-toggle">
+          <label for="heatmap-toggle">
+            <input type="checkbox" id="heatmap-toggle" />
+            Heatmap
+          </label>
         </div>
       </section>
       <ul id="fixture-list" aria-live="polite"></ul>

--- a/client/volumetrics.js
+++ b/client/volumetrics.js
@@ -1,0 +1,86 @@
+import * as THREE from "three";
+
+const _origin = new THREE.Vector3();
+const _target = new THREE.Vector3();
+const _direction = new THREE.Vector3();
+const _quaternion = new THREE.Quaternion();
+const _down = new THREE.Vector3(0, -1, 0);
+
+export function createVolumetricBeam(baseColor = new THREE.Color(1, 1, 1)) {
+  const geometry = new THREE.ConeGeometry(1, 1, 48, 1, true);
+  geometry.translate(0, -0.5, 0);
+  geometry.rotateX(Math.PI);
+
+  const uniforms = {
+    uColor: { value: baseColor.clone() },
+    uIntensity: { value: 0.0 },
+  };
+
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    vertexShader: /* glsl */ `
+      varying float vHeight;
+      varying float vRadial;
+
+      void main() {
+        vHeight = 1.0 - (position.y + 0.5);
+        vRadial = length(position.xz);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      uniform vec3 uColor;
+      uniform float uIntensity;
+      varying float vHeight;
+      varying float vRadial;
+
+      void main() {
+        float rim = smoothstep(0.5, 1.0, vRadial);
+        float axial = pow(clamp(vHeight, 0.0, 1.0), 1.4);
+        float body = (1.0 - rim) * axial;
+        float alpha = clamp(body * uIntensity, 0.0, 1.0);
+        if (alpha <= 0.002) {
+          discard;
+        }
+        vec3 color = uColor * (0.65 + 0.35 * (1.0 - vHeight));
+        gl_FragColor = vec4(color * uIntensity, alpha);
+      }
+    `,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = "VolumetricIESBeam";
+  mesh.renderOrder = 3;
+  return mesh;
+}
+
+export function updateVolumetricBeam({ mesh, light, target, intensity }) {
+  if (!mesh || !light || !target) return;
+
+  light.getWorldPosition(_origin);
+  target.getWorldPosition(_target);
+  _direction.copy(_target).sub(_origin);
+  const distance = Math.max(_direction.length(), 0.25);
+  _direction.normalize();
+
+  _quaternion.setFromUnitVectors(_down, _direction);
+  mesh.setRotationFromQuaternion(_quaternion);
+
+  const radius = Math.max(Math.tan(light.angle) * distance, 0.05);
+  mesh.scale.set(radius, distance, radius);
+
+  mesh.material.uniforms.uColor.value.copy(light.color);
+
+  const baseCandela = 1500;
+  const intensityFactor = THREE.MathUtils.clamp(intensity / baseCandela, 0, 12);
+  const spreadFactor = THREE.MathUtils.clamp((Math.PI / 2 - light.angle) / (Math.PI / 2) + 0.35, 0.25, 1.6);
+  const volumetricStrength = intensityFactor * spreadFactor;
+
+  mesh.material.uniforms.uIntensity.value = volumetricStrength;
+  mesh.visible = volumetricStrength > 0.001;
+}


### PR DESCRIPTION
## Summary
- add shader-driven volumetric cones for each loaded fixture and expose a sidebar toggle
- overlay a floor heatmap that approximates illuminance for the selected light with live updates from existing controls
- document the new toggles in the README and extend the Scene Controls UI with checkbox inputs

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5801c5b2c83258a2f2bffa2b3c4bb